### PR TITLE
Enhance Jekyll Dev Container Configuration with Live Reload and Dependabot Setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Jekyll",
-  "image": "mcr.microsoft.com/devcontainers/jekyll:2-bullseye",
+  "image": "mcr.microsoft.com/vscode/devcontainers/jekyll:bullseye",
   "onCreateCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
   "postCreateCommand": "bash .devcontainer/post-create.sh",
   "customizations": {

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  # Maintain dependencies for Ruby (Jekyll and Chirpy theme)
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+    allow:
+      - dependency-type: "all"
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -21,6 +21,17 @@
       },
       "problemMatcher": [],
       "detail": "Build the Jekyll site for production."
+    },
+    {
+      "label": "Serve Jekyll",
+      "type": "shell",
+      "command": "bundle exec jekyll serve",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": [],
+      "detail": "Serves the Jekyll site locally with live reload."
     }
   ]
 }


### PR DESCRIPTION
[[FIX] Update Jekyll image reference in devcontainer configuration
[ADDED] Add missing task for serving Jekyll site with live reload.
[ADDED] Initialize Dependabot configuration for Ruby and GitHub Actions dependencies